### PR TITLE
New lua function: nut_buffer_clip(buffer, offset, length)

### DIFF
--- a/API.md
+++ b/API.md
@@ -194,6 +194,10 @@ Append the `src` buffer to the `dst` buffer. Both buffers need to be of the same
 
 Return a new buffer that's a given percentage of the original buffer's size. Percentage is a value between 0.0-1.0. The returned buffer will have the same type as the input buffer.
 
+### nut_buffer_clip(buffer, offset, length)
+
+Return a new buffer that's a subset of the original buffer. The returned buffer will have the same type as the input buffer.
+
 ### nut_buffer_convert(buffer, new_type)
 
 Return a new buffer that's converted from the original type. `new_type` can be `NUT_BUFFER_U8` for unsigned bytes or `NUT_BUFFER_F64` for double-precision floating point values. Converting to the same type just creates a copy of the buffer.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,14 @@ static int l_nut_buffer_reduce(lua_State *L) {
     return l_push_nut_buffer(L, result);
 }
 
+static int l_nut_buffer_clip(lua_State *L) {
+    nut_buffer *buffer = l_to_nut_buffer(L, 1);
+    int offset = luaL_checkinteger(L, 2);
+    int length = luaL_checkinteger(L, 3);
+    nut_buffer *result = nut_buffer_clip(buffer, offset, length);
+    return l_push_nut_buffer(L, result);
+}
+
 static int l_nut_buffer_convert(lua_State *L) {
     nut_buffer *buffer = l_to_nut_buffer(L, 1);
     int new_type = luaL_checkinteger(L, 2);
@@ -1093,6 +1101,7 @@ static lua_State *l_init() {
 
     l_register_function(L, "nut_buffer_append", l_nut_buffer_append);
     l_register_function(L, "nut_buffer_reduce", l_nut_buffer_reduce);
+    l_register_function(L, "nut_buffer_clip", l_nut_buffer_clip);
     l_register_function(L, "nut_buffer_convert", l_nut_buffer_convert);
     l_register_function(L, "nut_buffer_save", l_nut_buffer_save);
     l_register_function(L, "nwm_get_time", l_nwm_get_time);

--- a/src/nut.c
+++ b/src/nut.c
@@ -68,6 +68,19 @@ nut_buffer *nut_buffer_reduce(nut_buffer *buffer, double percentage) {
     }
 }
 
+nut_buffer *nut_buffer_clip(nut_buffer *buffer, int offset, int length) {
+    assert(buffer != NULL);
+    assert((length < 0) || ((buffer->length - offset) >= length));
+    int new_length = length;
+    if (new_length < 0 || new_length > buffer->length - offset)
+      new_length = buffer->length - offset;
+    if (buffer->type == NUT_BUFFER_U8) {
+        return nut_buffer_new_u8(new_length, buffer->channels, buffer->data.u8 + offset);
+    } else {
+        return nut_buffer_new_f64(new_length, buffer->channels, buffer->data.f64 + offset);
+    }
+}
+
 void nut_buffer_set_data(nut_buffer *dst, nut_buffer *src) {
     assert(dst != NULL);
     assert(src != NULL);

--- a/src/nut.h
+++ b/src/nut.h
@@ -33,6 +33,7 @@ nut_buffer *nut_buffer_new_u8(int length, int channels, const uint8_t *data);
 nut_buffer *nut_buffer_new_f64(int length, int channels, const double *data);
 nut_buffer *nut_buffer_copy(nut_buffer *buffer);
 nut_buffer *nut_buffer_reduce(nut_buffer *buffer, double percentage);
+nut_buffer *nut_buffer_clip(nut_buffer *buffer, int offset, int length);
 void nut_buffer_set_data(nut_buffer *dst, nut_buffer *src);
 void nut_buffer_append(nut_buffer *dst, nut_buffer *src);
 uint8_t nut_buffer_get_u8(nut_buffer *buffer, int offset);


### PR DESCRIPTION

This pull request adds `nut_buffer_clip(buffer, offset, length)` to the exposed lua API.  The purpose of the function is to return a new buffer that's a subset of the original buffer.  Think of it like a `string.substr` function.

e.g. `nut_buffer_clip(buffer, 0, m)` will give you the first `m` samples of a buffer.

`nut_buffer_clip(buffer, n, m)` will give you the samples in the range `[n .. n+m]`.

`nut_buffer_clip(buffer, n, -1)` will give you all samples in the range `[n .. buffer.length]`.

`nut_buffer_clip(buffer, n, m)` when `n+m` is greater than `buffer.length` will give you all samples in the range `[n .. buffer.length]`.

This function turned out to be useful for some experimental lua scripts I was writing, so I figured maybe it'd be useful to others as well.

Thanks for the really cool frequency visualizer!